### PR TITLE
Fixing broken link to Lightning talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,4 +79,4 @@ Please submit a PR with your slides in a subdirectory named like this:
 
 ### Lightning Talks
 
-[Click here](lightningtalks/README.md)
+[Click here](lightningtalks/readme.md)


### PR DESCRIPTION
Broken link to lightning talks fixed. The directory contained a "readme.md" file and not a "README.md" file like the root directory. This can be fixed in another way by just renaming the file in the lightning talks directory to "README.md" from "readme.md" or just fixing the typo in this file (as I have done).